### PR TITLE
Update AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml

### DIFF
--- a/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
+++ b/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
@@ -14,8 +14,8 @@
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>7</min>
-              <max>9</max>
+              <min>20</min>
+              <max>20</max>
           </primaryMagazineCount>
           </li>
         </value>
@@ -27,8 +27,8 @@
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>2</min>
-              <max>2</max>
+              <min>100</min>
+              <max>100</max>
           </primaryMagazineCount>
           </li>
         </value>
@@ -41,8 +41,8 @@
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>10</min>
-              <max>15</max>
+              <min>50</min>
+              <max>50</max>
           </primaryMagazineCount>
           </li>
         </value>

--- a/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
+++ b/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
@@ -7,16 +7,37 @@
       <li Class="CombatExtended.PatchOperationFindMod">
         <modName>Alpha Animals</modName>
       </li>
-	  
-	  <!-- Fireworm and Siegebreaker -->
+	  	 	  <!-- Siegebreaker -->
 	  
       <li Class="PatchOperationAddModExtension">
-        <xpath>Defs/PawnKindDef[defName="AA_Fireworm" or defName="AA_Siegebreaker"]</xpath>
+        <xpath>Defs/PawnKindDef[defName="AA_Siegebreaker"]</xpath>
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>100</min>
-              <max>100</max>
+              <min>7</min>
+              <max>9</max>
+          </primaryMagazineCount>
+          </li>
+        </value>
+      </li>
+
+      <li Operation Class="PatchOperationReplace">
+  	<xpath>Defs/PawnKindDef[defName="AA_Siegebreaker"]/combatPower</xpath>
+  	<value>
+  		<combatPower>500</combatPower>
+  	</value>
+      </li>
+	    
+	  
+	  <!-- Fireworm-->
+
+      <li Class="PatchOperationAddModExtension">
+        <xpath>Defs/PawnKindDef[defName="AA_Fireworm"]</xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>2</min>
+              <max>2</max>
           </primaryMagazineCount>
           </li>
         </value>
@@ -29,8 +50,8 @@
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>100</min>
-              <max>200</max>
+              <min>10</min>
+              <max>15</max>
           </primaryMagazineCount>
           </li>
         </value>

--- a/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
+++ b/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
@@ -20,16 +20,7 @@
           </li>
         </value>
       </li>
-
-      <li Operation Class="PatchOperationReplace">
-  	<xpath>Defs/PawnKindDef[defName="AA_Siegebreaker"]/combatPower</xpath>
-  	<value>
-  		<combatPower>500</combatPower>
-  	</value>
-      </li>
-	    
-	  
-	  <!-- Fireworm-->
+	    <!-- Fireworm-->
 
       <li Class="PatchOperationAddModExtension">
         <xpath>Defs/PawnKindDef[defName="AA_Fireworm"]</xpath>


### PR DESCRIPTION
Separated fireworm and siege breaker ammo load.
Reduced mech magazine loadout so players aren't flooded with a gazillion ammo when mechs are killed.