### PR TITLE
Fireworm Balance

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
@@ -22,21 +22,21 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Fireworm"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Fireworm"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8.5</ArmorRating_Sharp>
 				</value>
 			</li>
 				
 					<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AA_Fireworm"]/statBases/MoveSpeed</xpath>
-		<value>
-			<MoveSpeed>2.8</MoveSpeed>
-		</value>
+				<xpath>Defs/ThingDef[defName="AA_Fireworm"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>3.4</MoveSpeed>
+				</value>
 			</li>
 			
 			

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
@@ -22,15 +22,22 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Fireworm"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Fireworm"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
-			</li>			
+			</li>
+				
+					<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_Fireworm"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>2.8</MoveSpeed>
+		</value>
+			</li>
 			
 			
 			<li Class="PatchOperationAdd">
@@ -51,7 +58,7 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>10</power>
+							<power>20</power>
 							<cooldownTime>2.6</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
@@ -62,7 +62,7 @@
 							<cooldownTime>2.6</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
 					  </li>
 					</tools>
 				</value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Fireworm.xml
@@ -58,7 +58,7 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>20</power>
+							<power>18</power>
 							<cooldownTime>2.6</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>


### PR DESCRIPTION
Increased fireworm armor and speed, slow movement, lowish armor and short-range make for a poor combo.
Increased melee damage so that it isn't risk-free to engage in melee.