### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Aura.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
@@ -23,11 +23,13 @@
 				<xpath>/Defs/ThingDef[defName="AA_Aura"]</xpath>
 				<value>
 					<statBases> <!-- Ok this is pissing me off -->
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
-						<MeleeDodgeChance>0.02</MeleeDodgeChance>
-						<MeleeCritChance>0.16</MeleeCritChance>
-						<MeleeParryChance>0.17</MeleeParryChance>
+					        <MoveSpeed>6</MoveSpeed>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+						<ArmorRating_Sharp>3</ArmorRating_Sharp>
+						<MeleeDodgeChance>0.33</MeleeDodgeChance>
+						<MeleeCritChance>0.24</MeleeCritChance>
+						<MeleeParryChance>0.33</MeleeParryChance>
+						<MaxHitPoints>200</MaxHitPoints>
 					</statBases>
 				</value>
 			</li>
@@ -42,11 +44,11 @@
 							  <li>Cut</li>
 							  <li>Stab</li>
 							</capacities>
-							<power>23</power>
-							<cooldownTime>2</cooldownTime>
+							<power>22</power>
+							<cooldownTime>0.7</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
 							<armorPenetrationSharp>18</armorPenetrationSharp>
 						</li>
       

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
@@ -23,7 +23,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_Aura"]</xpath>
 				<value>
 					<statBases> <!-- Ok this is pissing me off -->
-					        <MoveSpeed>6</MoveSpeed>
+					        <MoveSpeed>5.5</MoveSpeed>
 						<ArmorRating_Blunt>2</ArmorRating_Blunt>
 						<ArmorRating_Sharp>3</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.33</MeleeDodgeChance>
@@ -44,8 +44,8 @@
 							  <li>Cut</li>
 							  <li>Stab</li>
 							</capacities>
-							<power>22</power>
-							<cooldownTime>0.7</cooldownTime>
+							<power>21</power>
+							<cooldownTime>0.8</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 							<armorPenetrationBlunt>2</armorPenetrationBlunt>
@@ -57,7 +57,7 @@
 							<capacities>
 							  <li>Blunt</li>
 							</capacities>
-							<power>9</power>
+							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>


### PR DESCRIPTION
Differentiate Aura from Scyther by making it less armored, but faster, deal less damage per hit for more frequent attacks.
Various melee stats brought to par(or better) of an average scyther to make it more deadly in melee.