### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Daggersnout.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
@@ -23,10 +23,10 @@
 				<xpath>/Defs/ThingDef[defName="AA_Daggersnout"]</xpath>
 				<value>
 					<statBases> <!-- Actually having to add statBases.... -->
-						<ArmorRating_Blunt>13</ArmorRating_Blunt>
-						<ArmorRating_Sharp>21</ArmorRating_Sharp>
-						<MeleeDodgeChance>0.02</MeleeDodgeChance>
-						<MeleeCritChance>0.33</MeleeCritChance>
+						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+						<ArmorRating_Sharp>3</ArmorRating_Sharp>
+						<MeleeDodgeChance>0.1</MeleeDodgeChance>
+						<MeleeCritChance>0.3</MeleeCritChance>
 						<MeleeParryChance>0.17</MeleeParryChance>
 					</statBases>
 				</value>
@@ -42,12 +42,12 @@
 								  <li>Cut</li>
 								  <li>Stab</li>
 								</capacities>
-								<power>6</power>
-								<cooldownTime>1</cooldownTime>
+								<power>20</power>
+								<cooldownTime>1.7</cooldownTime>
 								<linkedBodyPartsGroup>AA_NoseBlade</linkedBodyPartsGroup>
 								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
-							<armorPenetrationSharp>15</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+							<armorPenetrationSharp>4</armorPenetrationSharp>
 						</li>
       
 						<li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
Not sure why Daggersnout has 21 sharp armor or 15 armor pen since it's a low tier screening mechanoid worth only 90 combat power.
For ref, the centipede is 580, Pikeman is 110,while scythers and lancers are both 150, Aura being 180 and Fireworm 300.