### PR TITLE
Update AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
@@ -12,7 +12,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
+						<bodyShape>QuadrupedLow</bodyShape>
 					</li>
 				</value>
 			</li>
@@ -34,8 +34,8 @@
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
-					<MeleeCritChance>0.5</MeleeCritChance>
-					<MeleeParryChance>0.5</MeleeParryChance>
+					<MeleeCritChance>0.3</MeleeCritChance>
+					<MeleeParryChance>0.35</MeleeParryChance>
 				</value>
 			</li>
 
@@ -48,22 +48,22 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>40</power>
-							<cooldownTime>3.6</cooldownTime>
+							<power>20</power>
+							<cooldownTime>2.5</cooldownTime>
 							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
-							<armorPenetrationSharp>9</armorPenetrationSharp>
-							<armorPenetrationBlunt>18</armorPenetrationBlunt>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>16</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>24</power>
-							<cooldownTime>3</cooldownTime>
+							<power>15</power>
+							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<armorPenetrationBlunt>17</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
@@ -12,7 +12,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>QuadrupedLow</bodyShape>
+						<bodyShape>Quadruped</bodyShape>
 					</li>
 				</value>
 			</li>
@@ -20,7 +20,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -33,9 +33,9 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases</xpath>
 				<value>
-					<MeleeDodgeChance>0.17</MeleeDodgeChance>
-					<MeleeCritChance>0.1</MeleeCritChance>
-					<MeleeParryChance>0.18</MeleeParryChance>
+					<MeleeDodgeChance>0.01</MeleeDodgeChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
 				</value>
 			</li>
 
@@ -48,23 +48,22 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>18</power>
-							<cooldownTime>2</cooldownTime>
+							<power>40</power>
+							<cooldownTime>3.6</cooldownTime>
 							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
-							<armorPenetrationSharp>40</armorPenetrationSharp>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<armorPenetrationSharp>9</armorPenetrationSharp>
+							<armorPenetrationBlunt>18</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>6</power>
-							<cooldownTime>2</cooldownTime>
+							<power>24</power>
+							<cooldownTime>3</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationSharp>5</armorPenetrationSharp>
-							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
@@ -12,7 +12,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>QuadrupedLow</bodyShape>
+						<bodyShape>Quadruped</bodyShape>
 					</li>
 				</value>
 			</li>


### PR DESCRIPTION
Giant beetles are big and strong, I wouldn’t give them such high armour pen since they aren’t genetically engineered mech killers.

Normally I would suggest that legs aren’t covered by armour, but this creatures uses a vanilla body type with no exposed body parts(can’t be modified without changing CE core patches), so ehhh.