### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Gallatross.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -23,11 +23,17 @@
 					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
-					<MeleeCritChance>0.1</MeleeCritChance>
-					<MeleeParryChance>0.36</MeleeParryChance>
+					<MeleeCritChance>1.75</MeleeCritChance>
+					<MeleeParryChance>0.25</MeleeParryChance>
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+		                 <xpath>Defs/ThingDef[defName="AA_Gallatross"]/race/baseHealthScale</xpath>
+		                 <value>
+			               <baseHealthScale>15</baseHealthScale>
+		                 </value>
+	                </li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/tools</xpath>
 				<value>
@@ -37,29 +43,30 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>27</power>
-							<cooldownTime>1.5</cooldownTime>
+							<power>78</power>
+							<cooldownTime>2.2</cooldownTime>
 							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>31.226</armorPenetrationBlunt>	
+							<armorPenetrationBlunt>40.226</armorPenetrationBlunt>	
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>1.65</cooldownTime>
+							<power>40</power>
+							<cooldownTime>2.0</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>21</armorPenetrationBlunt>	
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+							<armorPenetrationBlunt>28</armorPenetrationBlunt>	
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>9</power>
-							<cooldownTime>1.65</cooldownTime>
+							<power>36</power>
+							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>	
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>	
 							<chanceFactor>0.1</chanceFactor>
 						</li>
 					</tools>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -43,8 +43,8 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>78</power>
-							<cooldownTime>2.2</cooldownTime>
+							<power>70</power>
+							<cooldownTime>2.5</cooldownTime>
 							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>40.226</armorPenetrationBlunt>	
 						</li>


### PR DESCRIPTION
The creature originally has a 40x health scale which doesn't work well with CE at all, it will invariably bleed to death way before bullets put even a dent on its enormous health pool, rendering it pointless. I'm thinking of making of adding a hediff to the creature which reduces bleeding. but either way, the healthscale needs to be reduced.