### PR TITLE
Update AlphaAnimals_CE_Patch_Race_CrystalMit.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
@@ -26,16 +26,16 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/statBases</xpath>
 				<value>
-					<MeleeDodgeChance>0.02</MeleeDodgeChance>
-					<MeleeCritChance>0.07</MeleeCritChance>
-					<MeleeParryChance>0.04</MeleeParryChance>
+					<MeleeDodgeChance>0.01</MeleeDodgeChance>
+					<MeleeCritChance>0.01</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
 
@@ -47,8 +47,8 @@
 								<capacities>
 								  <li>Bite</li>
 								</capacities>
-								<power>8</power>
-								<cooldownTime>2.6</cooldownTime>
+								<power>6</power>
+								<cooldownTime>2.4</cooldownTime>
 								<linkedBodyPartsGroup>TurtleBeakAttackTool</linkedBodyPartsGroup>
 								<armorPenetrationSharp>0.43</armorPenetrationSharp>
 								<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
@@ -58,8 +58,8 @@
 								<capacities>
 								  <li>Blunt</li>
 								</capacities>
-								<power>4</power>
-								<cooldownTime>1.65</cooldownTime>
+								<power>2</power>
+								<cooldownTime>1.2</cooldownTime>
 								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 								<armorPenetrationBlunt>0.750</armorPenetrationBlunt>
 								<chanceFactor>0.2</chanceFactor>


### PR DESCRIPTION
20 RHa is really excessive for a small creature, again, the armour coverage is incomplete.
A complication of an overly armored small critter is that predator on the map will queue up to suicide itself on it.