### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>7</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>7</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -47,8 +47,8 @@
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>8</power>
-							<cooldownTime>2.6</cooldownTime>
+							<power>6</power>
+							<cooldownTime>2.2</cooldownTime>
 							<linkedBodyPartsGroup>TurtleBeakAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.33</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.750</armorPenetrationBlunt>


### PR DESCRIPTION
Pebble and crystal mitt may need a tag which prevents it from being hunted, since most predator can't hurt it at all should it acquire all-around armor coverage.