### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Blizzarisk.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -108,6 +108,20 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+				</value>
+			</li>
+
+	               <li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases</xpath>
 				<value>
@@ -117,20 +131,6 @@
 				</value>
 			</li>
 				
-			<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>5</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	               <li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>3</ArmorRating_Sharp>
-		</value>
-	</li>
-
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/tools</xpath>
 				<value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -49,7 +49,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>15</power>
+							<power>13</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -60,7 +60,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>15</power>
+							<power>13</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -70,7 +70,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>22</power>
+							<power>18</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -140,28 +140,28 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>24</power>
+							<power>22</power>
 							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
-							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right first leg</label>
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>24</power>
+							<power>22</power>
 							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
-							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>40</power>
+							<power>32</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -172,18 +172,18 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>20</armorPenetrationSharp>
-							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>20</power>
+							<power>15</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 							<chanceFactor>0.5</chanceFactor>
 						</li>
 					</tools>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -17,6 +17,20 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/statBases</xpath>
 				<value>
@@ -25,20 +39,6 @@
 					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
-				
-					<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>1</ArmorRating_Blunt>
-		</value>
-	</li>
-
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>1</ArmorRating_Sharp>
-		</value>
-	</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/tools</xpath>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -21,10 +21,24 @@
 				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-					<MeleeCritChance>0.1</MeleeCritChance>
-					<MeleeParryChance>0.12</MeleeParryChance>
+					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
+				
+					<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+		</value>
+	</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/tools</xpath>
@@ -35,28 +49,28 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>1.5</cooldownTime>
+							<power>15</power>
+							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right first leg</label>
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>1.5</cooldownTime>
+							<power>15</power>
+							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>15</power>
+							<power>22</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -67,8 +81,8 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.8</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
@@ -98,9 +112,24 @@
 				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.11</MeleeDodgeChance>
-					<MeleeCritChance>0.1</MeleeCritChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.25</MeleeParryChance>
 				</value>
 			</li>
+				
+			<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>5</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	               <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+		</value>
+	</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/tools</xpath>
@@ -111,29 +140,29 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>1.5</cooldownTime>
+							<power>24</power>
+							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right first leg</label>
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>1.5</cooldownTime>
+							<power>24</power>
+							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>15</power>
-							<cooldownTime>1.65</cooldownTime>
+							<power>40</power>
+							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -143,19 +172,19 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.8</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>10</power>
+							<power>20</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>1</armorPenetrationBlunt>
-							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+							<chanceFactor>0.5</chanceFactor>
 						</li>
 					</tools>
 				</value>


### PR DESCRIPTION
Keeping the blunt armor low so you could bash a baby spider to death with your weapon. It could use a higher armor value should it have incomplete armor coverage, but for now, it is to be kept low due to how common giant spiders are.