### PR TITLE
Update AlphaAnimals_CE_Patch_Projectiles.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -42,7 +42,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>7</damageAmountBase>
-						<speed>40</speed>
+						<speed>25</speed>
 						<armorPenetrationSharp>1.5</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 					</projectile>
@@ -56,7 +56,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>8</damageAmountBase>
-						<speed>40</speed>
+						<speed>27</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 					</projectile>
@@ -70,7 +70,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>11</damageAmountBase>
-						<speed>40</speed>
+						<speed>27</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 					</projectile>
@@ -98,7 +98,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>20</damageAmountBase>
-						<speed>35</speed>
+						<speed>30</speed>
 						<armorPenetrationSharp>3</armorPenetrationSharp>
 						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 					</projectile>
@@ -112,7 +112,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>7</damageAmountBase>
-						<speed>40</speed>
+						<speed>27</speed>
 						<armorPenetrationSharp>1.5</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 					</projectile>
@@ -127,7 +127,7 @@
 						<damageDef>Bomb</damageDef>
 						<damageAmountBase>35</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
-						<speed>18</speed>
+						<speed>12</speed>
 						<armorPenetrationSharp>5</armorPenetrationSharp>
 						<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -222,7 +222,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_ToxicInk"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>30</speed>
+						<speed>25</speed>
 						<damageDef>AA_ToxicBolt</damageDef>
 						<damageAmountBase>40</damageAmountBase>
 						<explosionRadius>3</explosionRadius>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -123,9 +123,9 @@
 				<xpath>/Defs/ThingDef[defName="AA_Bullet_Rock"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<explosionRadius>1</explosionRadius>
+						<explosionRadius>1.5</explosionRadius>
 						<damageDef>Bomb</damageDef>
-						<damageAmountBase>35</damageAmountBase>
+						<damageAmountBase>40</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
 						<speed>16</speed>
 						<armorPenetrationSharp>5</armorPenetrationSharp>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -55,8 +55,8 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>11</damageAmountBase>
-						<speed>30</speed>
+						<damageAmountBase>8</damageAmountBase>
+						<speed>40</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 					</projectile>
@@ -69,7 +69,7 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>8</damageAmountBase>
+						<damageAmountBase>11</damageAmountBase>
 						<speed>40</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -84,7 +84,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>Flame</damageDef>
 						<damageAmountBase>24</damageAmountBase>
-						<speed>24</speed>
+						<speed>30</speed>
 						<armorPenetrationSharp>16</armorPenetrationSharp>
 						<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 					</projectile>
@@ -98,7 +98,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>20</damageAmountBase>
-						<speed>20</speed>
+						<speed>35</speed>
 						<armorPenetrationSharp>3</armorPenetrationSharp>
 						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 					</projectile>
@@ -111,10 +111,10 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>4</damageAmountBase>
-						<speed>28</speed>
-						<armorPenetrationSharp>1</armorPenetrationSharp>
-						<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+						<damageAmountBase>7</damageAmountBase>
+						<speed>40</speed>
+						<armorPenetrationSharp>1.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 					</projectile>
 				</value>
 			</li>
@@ -125,11 +125,11 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<explosionRadius>1</explosionRadius>
 						<damageDef>Bomb</damageDef>
-						<damageAmountBase>40</damageAmountBase>
+						<damageAmountBase>35</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
-						<speed>20</speed>
-						<armorPenetrationSharp>10</armorPenetrationSharp>
-						<armorPenetrationBlunt>18</armorPenetrationBlunt>
+						<speed>18</speed>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 					</projectile>
 				</value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -41,9 +41,9 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>5</damageAmountBase>
-						<speed>64</speed>
-						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<damageAmountBase>7</damageAmountBase>
+						<speed>40</speed>
+						<armorPenetrationSharp>1.5</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 					</projectile>
 				</value>
@@ -55,8 +55,8 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>8</damageAmountBase>
-						<speed>40</speed>
+						<damageAmountBase>11</damageAmountBase>
+						<speed>30</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 					</projectile>
@@ -83,8 +83,8 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>Flame</damageDef>
-						<damageAmountBase>20</damageAmountBase>
-						<speed>25</speed>
+						<damageAmountBase>24</damageAmountBase>
+						<speed>24</speed>
 						<armorPenetrationSharp>16</armorPenetrationSharp>
 						<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 					</projectile>
@@ -99,8 +99,8 @@
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>20</damageAmountBase>
 						<speed>20</speed>
-						<armorPenetrationSharp>8</armorPenetrationSharp>
-						<armorPenetrationBlunt>1.750</armorPenetrationBlunt>
+						<armorPenetrationSharp>3</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 					</projectile>
 				</value>
 			</li>
@@ -111,10 +111,10 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>3</damageAmountBase>
-						<speed>35</speed>
-						<armorPenetrationSharp>6</armorPenetrationSharp>
-						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
+						<damageAmountBase>4</damageAmountBase>
+						<speed>28</speed>
+						<armorPenetrationSharp>1</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 					</projectile>
 				</value>
 			</li>
@@ -125,7 +125,7 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<explosionRadius>1</explosionRadius>
 						<damageDef>Bomb</damageDef>
-						<damageAmountBase>35</damageAmountBase>
+						<damageAmountBase>40</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
 						<speed>20</speed>
 						<armorPenetrationSharp>10</armorPenetrationSharp>
@@ -141,8 +141,8 @@
 					<comps>				
 						<li Class="CombatExtended.CompProperties_Fragments">
 							<fragments>
-							<Fragment_Small>14</Fragment_Small>
-							<Fragment_Large>4</Fragment_Large>
+							<Fragment_Small>18</Fragment_Small>
+							<Fragment_Large>5</Fragment_Large>
 							</fragments>
 						</li>
 					</comps>
@@ -205,7 +205,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_IncendiaryMote"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>40</speed>
+						<speed>30</speed>
 						<damageDef>Flame</damageDef>
 						<damageAmountBase>15</damageAmountBase>
 						<explosionRadius>1.1</explosionRadius>
@@ -222,7 +222,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_ToxicInk"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>40</speed>
+						<speed>30</speed>
 						<damageDef>AA_ToxicBolt</damageDef>
 						<damageAmountBase>40</damageAmountBase>
 						<explosionRadius>3</explosionRadius>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -42,7 +42,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>7</damageAmountBase>
-						<speed>25</speed>
+						<speed>34</speed>
 						<armorPenetrationSharp>1.5</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 					</projectile>
@@ -69,7 +69,7 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
-						<damageAmountBase>11</damageAmountBase>
+						<damageAmountBase>12</damageAmountBase>
 						<speed>27</speed>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -98,9 +98,9 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>AA_ToxicSting</damageDef>
 						<damageAmountBase>20</damageAmountBase>
-						<speed>30</speed>
+						<speed>20</speed>
 						<armorPenetrationSharp>3</armorPenetrationSharp>
-						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+						<armorPenetrationBlunt>3</armorPenetrationBlunt>
 					</projectile>
 				</value>
 			</li>
@@ -127,7 +127,7 @@
 						<damageDef>Bomb</damageDef>
 						<damageAmountBase>35</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
-						<speed>12</speed>
+						<speed>16</speed>
 						<armorPenetrationSharp>5</armorPenetrationSharp>
 						<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>


### PR DESCRIPTION
Animal range attack are much like bows and arrow than bullets, hence I nerfed most of them in terms of speed, penetration but sometimes, higher damage. Increased gallatross damage and increased fragmentation, since a reduction from radii 2 to 1 result in a huge reduction in blast radius(9 tiles to 1 tile).

Feel free to discuss.