### PR TITLE
Update AlphaAnimals_CE_Patch_RangedMechanoid.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -91,7 +91,7 @@
 			  <range>16</range>
 			  <ticksBetweenBurstShots>0.5</ticksBetweenBurstShots>
 			  <burstShotCount>5</burstShotCount>
-			  <soundCast>FlameThrower</soundCast>
+			  <soundCast>HissFlamethrower</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
 				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 			</Properties>

--- a/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -91,7 +91,7 @@
 			  <range>16</range>
 			  <ticksBetweenBurstShots>0.5</ticksBetweenBurstShots>
 			  <burstShotCount>5</burstShotCount>
-			  <soundCast>HissFlamethrower</soundCast>
+			  <soundCast>AA_PoisonBolt</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
 				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 			</Properties>


### PR DESCRIPTION
Soundcast flamethrower does not exist, switched to using FlamethrowerHiss form CE guns instead, yes, It wouldn't work without CE guns, but otherwise, the game uses the completely unfit throw Molotov sound effect which is worse than nothing.