### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Plasmorph.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 				</value>
 			</li>
 
@@ -35,7 +35,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
-					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeCritChance>0.05</MeleeCritChance>
 					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
@@ -49,10 +49,10 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>18</power>
-							<cooldownTime>1.65</cooldownTime>
+							<power>7</power>
+							<cooldownTime>2.4</cooldownTime>
 							<linkedBodyPartsGroup>AA_EyestalkAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
@@ -12,7 +12,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Serpentine</bodyShape>
+						<bodyShape>Quadrupedlow</bodyShape>
 					</li>
 				</value>
 			</li>
@@ -49,7 +49,7 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>7</power>
+							<power>8</power>
 							<cooldownTime>2.4</cooldownTime>
 							<linkedBodyPartsGroup>AA_EyestalkAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
@@ -12,7 +12,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadrupedlow</bodyShape>
+						<bodyShape>Serpentine</bodyShape>
 					</li>
 				</value>
 			</li>
@@ -49,10 +49,10 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>8</power>
-							<cooldownTime>2.4</cooldownTime>
+							<power>16</power>
+							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>AA_EyestalkAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>


### PR DESCRIPTION
Stats tweaked to better match a creature of its size. TBH, the default stats of AA is pretty whack, a small snail hitting people with its eyestalk somehow does considerably more damage than the claws of a giant aerial predator.
So my tweaks may be drastic.