### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Bumbledrone.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
@@ -34,7 +34,7 @@
 							<capacities>
 								<li>AA_VeryToxicSting</li>
 							</capacities>
-							<power>9</power>
+							<power>10</power>
 							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>AA_Sting</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1.25</armorPenetrationSharp>
@@ -154,7 +154,7 @@
 							<capacities>
 								<li>AA_VeryToxicSting</li>
 							</capacities>
-							<power>14</power>
+							<power>15</power>
 							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>AA_Sting</linkedBodyPartsGroup>
 							<armorPenetrationSharp>2</armorPenetrationSharp>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
@@ -34,7 +34,7 @@
 							<capacities>
 								<li>AA_VeryToxicSting</li>
 							</capacities>
-							<power>10</power>
+							<power>9</power>
 							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>AA_Sting</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1.25</armorPenetrationSharp>
@@ -46,7 +46,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>9</power>
+							<power>8</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.1</chanceFactor>
@@ -94,7 +94,7 @@
 							<capacities>
 								<li>AA_VeryToxicSting</li>
 							</capacities>
-							<power>15</power>
+							<power>16</power>
 							<cooldownTime>1.55</cooldownTime>
 							<linkedBodyPartsGroup>AA_Sting</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1.25</armorPenetrationSharp>
@@ -106,7 +106,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>18</power>
+							<power>19</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.5</chanceFactor>
@@ -166,7 +166,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>9</power>
+							<power>8</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.1</chanceFactor>


### PR DESCRIPTION
Reduced the attack power of bumbledrone and bumbledrone queen alittle, they aren’t dangerous in without CE and I kinda over-tuned them alittle beforehand.
Everything looks generally fine.