### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Feralisk.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -159,7 +159,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>37</power>
+							<power>35</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -48,7 +48,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
+							<power>13</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -59,7 +59,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>12</power>
+							<power>13</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -69,7 +69,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>16</power>
+							<power>18</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -159,7 +159,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>13</power>
+							<power>37</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>


### PR DESCRIPTION
Feralisks doesn’t need to have weaker baseattack power, the lack of elemental damage already makes it weaker than other spiders.