### PR TITLE
Update AlphaAnimals_CE_Patch_RangedMechanoid.xml

### DIFF
--- a/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -28,8 +28,8 @@
 			  <defaultProjectile>Bullet_120mmCannonShell_HE</defaultProjectile>
 			  <warmupTime>5</warmupTime>
 			  <range>88</range>
-			  <minRange>6</minRange>
-			  <soundCast>InfernoCannon_Fire</soundCast>
+			  <minRange>8</minRange>
+			  <soundCast>120mm</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
 				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 			</Properties>


### PR DESCRIPTION
Siege canon now use the 90mm flak canon firing effect. Slightly raised the minimum range.